### PR TITLE
Add noDefaultOutput option

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -24,6 +24,8 @@ module.exports = (cwd, list, cmd, args, ctx) => {
 
             if (list) {
 
+                ctx.output(''); // Just a newline to make some room
+
                 const pluginNames = Object.keys(server.plugins);
                 const commandList = pluginNames.reduce((collect, pluginName) => {
 
@@ -64,6 +66,7 @@ module.exports = (cwd, list, cmd, args, ctx) => {
             }
 
             if (!commandInfo.noDefaultOutput) {
+                ctx.output(''); // Just a newline to make some room
                 ctx.output(ctx.colors.green(`Running ${cmd}...\n`));
             }
 

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -63,11 +63,19 @@ module.exports = (cwd, list, cmd, args, ctx) => {
                 throw new DisplayError(ctx.colors.red(`Plugin ${pluginName} does not have ` + ((rawCommandName === 'default') ? 'a default command.' : `the command "${rawCommandName}".`)));
             }
 
-            ctx.output(ctx.colors.green(`Running ${cmd}...\n`));
+            if (!commandInfo.noDefaultOutput) {
+                ctx.output(ctx.colors.green(`Running ${cmd}...\n`));
+            }
 
             return Promise.resolve()
                 .then(() => commandInfo.command(server, args, root, ctx))
-                .then(() => ctx.output(ctx.colors.green('\nComplete!')))
+                .then(() => {
+
+                    if (!commandInfo.noDefaultOutput) {
+                        return ctx.output(ctx.colors.green('\nComplete!'));
+                    }
+                    return Promise.resolve();
+                })
                 .then(() => server)
                 .catch((err) => {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,6 @@ exports.start = (options) => {
     const colors = Print.colors(options.colors);
     const ctx = { options, colors, output, DisplayError };
 
-    output(''); // Just a newline to make some room
-
     const commandAndPart = (args instanceof Error) ? options.argv[2] : args._[2];
     const extraArgs = (commandAndPart === 'run') ? options.argv : args._;
 
@@ -40,6 +38,10 @@ exports.start = (options) => {
 
     const command = commandAndPart.split(':')[0];
     const cmdPart = commandAndPart.split(':')[1];
+
+    if (command !== 'run') {
+        output(''); // Just a newline to make some room
+    }
 
     switch (command) {
         case 'make': {

--- a/test/closet/run-silent-command/package.json
+++ b/test/closet/run-silent-command/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-silent-command"
+}

--- a/test/closet/run-silent-command/server.js
+++ b/test/closet/run-silent-command/server.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+exports.deployment = () => {
+
+    const server = new Hapi.Server();
+
+    const plugin = (srv, options, next) => {
+
+        srv.expose('commands', {
+
+            someCommand: {
+
+                // Make hpal silent before and after the command is run
+                noDefaultOutput: true,
+
+                command: (cmdSrv, args, root, ctx) => {
+
+                    return Promise.resolve().then(() => {
+
+                        ctx.options.cmd = [cmdSrv, args, root, ctx];
+
+                        const stop = cmdSrv.stop;
+                        cmdSrv.stop = () => {
+
+                            cmdSrv.stop = stop;
+
+                            return cmdSrv.stop().then(() => {
+
+                                cmdSrv.stopped = true;
+                            });
+                        };
+                    });
+                }
+            }
+        });
+
+        return next();
+    };
+
+    plugin.attributes = {
+        name: 'x'
+    };
+
+    return server.register(plugin).then(() => server);
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1522,6 +1522,17 @@ describe('hpal', () => {
                     });
             });
 
+            it('runs a command and prevents default output', () => {
+
+                return RunUtil.cli(['run', 'x:some-command'], 'run-silent-command')
+                    .then((result) => {
+
+                        expect(result.err).to.not.exist();
+                        expect(result.errorOutput).to.equal('');
+                        expect(result.output).to.equal('\n');
+                    });
+            });
+
             it('stops server when a DisplayError is thrown.', () => {
 
                 return RunUtil.cli(['run', 'x:some-command'], 'run-command-display-error')

--- a/test/index.js
+++ b/test/index.js
@@ -1529,7 +1529,7 @@ describe('hpal', () => {
 
                         expect(result.err).to.not.exist();
                         expect(result.errorOutput).to.equal('');
-                        expect(result.output).to.equal('\n');
+                        expect(result.output).to.equal('');
                     });
             });
 


### PR DESCRIPTION
- Adds ability to set a flag for `noDefaultOutput` on a command, which will cause the output given from hpal to be emptystring `''`