### PR TITLE
Fix `git clone` for working directories containing spaces

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -17,7 +17,7 @@ module.exports = (cwd, dir, ctx) => {
     return internals.ensureGitAndNpm(ctx)
         .then(() => {
 
-            return Helpers.exec(`git clone --depth=1 --origin=pal --branch=${PAL_BRANCH} ${PAL_REPO} ${dir}`, { cwd })
+            return Helpers.exec(`git clone --depth=1 --origin=pal --branch=${PAL_BRANCH} ${PAL_REPO} "${dir}"`, { cwd })
                 .catch((err) => {
 
                     if (~err.message.indexOf('already exists and is not an empty directory')) {


### PR DESCRIPTION
`npx hpal new my-project` will fail if the current path contains any spaces:

```
❯ npx hpal new my-project
npx: Installed 54 in 2.755s

Error: Command failed: git clone --depth=1 --origin=pal --branch=pal https://github.com/hapipal/boilerplate.git /Users/frederic/GitHub Projects/my-project
fatal: Too many arguments.
```