### PR TITLE
Camelize commands keys

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -135,5 +135,15 @@ internals.getCommand = (server, commandName, pluginName) => {
 
     return server.plugins[pluginName] &&
         server.plugins[pluginName].commands &&
-        server.plugins[pluginName].commands[commandName];
+        internals.camelizeKeys(server.plugins[pluginName].commands)[commandName];
+};
+
+internals.camelizeKeys = (obj) => {
+
+    return Object.keys(obj).reduce((camelObj, key) => {
+
+        const val = obj[key];
+        camelObj[internals.camelize(key)] = val;
+        return camelObj;
+    }, {});
 };


### PR DESCRIPTION
The `commandName` variable is normalized via `camelize` so if we normalize the object keys we should be all set