### PR TITLE
Support relative paths in Print.requires

### DIFF
--- a/lib/print.js
+++ b/lib/print.js
@@ -77,9 +77,10 @@ exports.example = (example, space) => {
 exports.requires = (example) => {
 
     const requires = (example && example.$requires) || [];
+    const relativePathRegex = /^\.[\./]+/;
 
     return requires
-        .map((dep) => `const ${internals.pascalize(dep)} = require('${dep}');`)
+        .map((dep) => `const ${internals.pascalize(dep.replace(relativePathRegex, ''))} = require('${dep}');`)
         .join(Os.EOL);
 };
 

--- a/test/print.js
+++ b/test/print.js
@@ -463,11 +463,13 @@ describe('Print.requires()', () => {
 
     it('prints an example\'s requires.', (done) => {
 
-        const ex = { $requires: ['five-spot', 'ten-spot'] };
+        const ex = { $requires: ['five-spot', 'ten-spot', './index', '../../two-levels-up'] };
 
         expect(Print.requires(ex)).to.equal([
             'const FiveSpot = require(\'five-spot\');',
-            'const TenSpot = require(\'ten-spot\');'
+            'const TenSpot = require(\'ten-spot\');',
+            'const Index = require(\'./index\');',
+            'const TwoLevelsUp = require(\'../../two-levels-up\');'
         ].join(Os.EOL));
 
         done();


### PR DESCRIPTION
Allows for relative path importing in .hc.js files.

Use case is for people (like me) with custom database models or such that want to do something like

```javascript
module.exports = {
    add: [{
        place: 'models',
        list: true,
        signature: ['name', 'schema'],
        method: (server, options, name, schema) => {

            const { Database } = server.app;

            server.app.models = server.app.models || {};
            server.app.models[name] = Database.addModel(name, schema);
        },
        example: {
            $requires: [
                'atlas',
                './database'
            ],
            $value: {
                name: 'ModelName',
                schema: { $literal: 'Database.addModel(\'ModelName\', new Atlas.Model())'}
            }
        }
    }]
};
```