### PR TITLE
[feat] Disable use strict header via noUseStrictHeader: true

### DIFF
--- a/lib/commands/make.js
+++ b/lib/commands/make.js
@@ -61,9 +61,16 @@ module.exports = (cwd, place, name, asDir, ctx) => {
                 const shouldBeListed = item.list && !name;
                 const requires = Print.requires(ex);
 
-                return ([].concat(
+                let useStrict = [
                     '\'use strict\';',
-                    '',
+                    ''
+                ];
+                if (item.noUseStrictHeader) {
+                    useStrict = [];
+                }
+
+                return ([].concat(
+                    useStrict,
                     requires ? [requires, ''] : [],
                     `module.exports = ${Print.example(shouldBeListed ? [ex] : ex)};`,
                     ''

--- a/test/closet/skip-use-strict-header/lib/.hc.js
+++ b/test/closet/skip-use-strict-header/lib/.hc.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = [{
+    method: 'x',
+    place: 'x',
+    noUseStrictHeader: true,
+}];

--- a/test/closet/skip-use-strict-header/node_modules
+++ b/test/closet/skip-use-strict-header/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/skip-use-strict-header/package.json
+++ b/test/closet/skip-use-strict-header/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "no-use-strict-header"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -615,6 +615,27 @@ describe('hpal', () => {
                     .then(() => RunUtil.cli(['make', 'x', 'y'], 'listed-example'))
                     .then(checkNamed);
             });
+
+            it('skips outputting the use strict header.', () => {
+
+                const check = (result) => {
+
+                    expect(result.err).to.not.exist();
+                    expect(result.output).to.contain('Wrote lib/x.js');
+                    expect(result.errorOutput).to.equal('');
+
+                    return read('skip-use-strict-header/lib/x.js')
+                        .then((contents) => {
+
+                            expect(contents).not.to.startWith('\'use strict\';');
+
+                            return rimraf('skip-use-strict-header/lib/x.js');
+                        });
+                };
+
+                return RunUtil.cli(['make', 'x'], 'skip-use-strict-header')
+                    .then(check);
+            });
         });
 
         describe('new command', () => {


### PR DESCRIPTION
This PR allows the setting of `noUseStrictHeader: true` in individual item files to disable outputting of `'use strict';` at the top of every file.

haute-couture PR coming shortly to enable setting this as a global amendment.