### PR TITLE
append EOL in generated package.json when runnning hpal new command

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -53,8 +53,10 @@ module.exports = async (cwd, dir, ctx) => {
     delete pkg.name;
     delete pkg.version;
 
+    const stringifiedPkg = JSON.stringify(pkg);
+
     await Promise.all([
-        Helpers.writeFile(Path.join(dir, 'package.json'), JSON.stringify(pkg)),
+        Helpers.writeFile(Path.join(dir, 'package.json'), `${stringifiedPkg}${Os.EOL}`),
         Helpers.writeFile(Path.join(dir, 'README.md'), '')
     ]);
 
@@ -91,8 +93,9 @@ module.exports = async (cwd, dir, ctx) => {
         return xScore - yScore;
     };
 
+    const finalPkgStringified = StableStringify(finalPkg, { cmp, space: 2 });
     await Promise.all([
-        Helpers.writeFile(Path.join(dir, 'package.json'), StableStringify(finalPkg, { cmp, space: 2 })),
+        Helpers.writeFile(Path.join(dir, 'package.json'), `${finalPkgStringified}${Os.EOL}`),
         Helpers.writeFile(Path.join(dir, 'README.md'), `# ${pkg.name}${Os.EOL}`)
     ]);
 

--- a/test/index.js
+++ b/test/index.js
@@ -693,7 +693,8 @@ describe('hpal', () => {
                     returnError(exec('git log', 'new/my-project'))
                 ]);
 
-                const pkg = JSON.parse(results[0]);
+                const pkgAsString = results[0];
+                const pkg = JSON.parse(pkgAsString);
                 const lib = results[1];
                 const test = results[2];
                 const remotes = results[3][0].split('\n');
@@ -705,6 +706,7 @@ describe('hpal', () => {
                 expect(pkg.version).to.equal('1.0.0');
                 expect(pkg.dependencies).to.exist();
                 expect(pkg.devDependencies).to.exist();
+                expect(pkgAsString.endsWith('\n')).to.equal(true);
                 expect(lib).to.exist();
                 expect(test).to.exist();
                 expect(remotes).to.contain('pal');
@@ -742,7 +744,8 @@ describe('hpal', () => {
                     returnError(exec('git log', 'new/bail-on-npm-init'))
                 ]);
 
-                const pkg = JSON.parse(results[0]);
+                const pkgAsString = results[0];
+                const pkg = JSON.parse(pkgAsString);
                 const lib = results[1];
                 const test = results[2];
                 const remotes = results[3][0].split('\n');
@@ -754,6 +757,7 @@ describe('hpal', () => {
                 expect(pkg.version).to.not.exist();
                 expect(pkg.dependencies).to.exist();
                 expect(pkg.devDependencies).to.exist();
+                expect(pkgAsString.endsWith('\n')).to.equal(true);
                 expect(lib).to.exist();
                 expect(test).to.exist();
                 expect(remotes).to.contain('pal');


### PR DESCRIPTION
Hey,

This PR is related to #29 
What you think about it ? Are my steps are corrects ? :)

IMO, I can see one improvement since EOL appending is used three times, it might be nice to extract a dedicated function to handle this case ?

Franck