### PR TITLE
Support windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,10 @@ os:
   - "linux"
   - "windows"
 
+before_script: |
+  if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
+    git config core.symlinks true
+    git reset --hard
+  fi
+
 after_script: "npm run coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: node_js
 node_js:
   - "8"
   - "10"
+  - "12"
   - "node"
 
 os:
   - "linux"
-  - "osx"
   - "windows"
 
 after_script: "npm run coveralls"

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -119,7 +119,11 @@ internals.npmInit = (cwd, ctx) => {
 
     return new Promise((resolve, reject) => {
 
+        // There is no way to cover this on a single platform
+        /* $lab:coverage:off$ */
         const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+        /* $lab:coverage:on$ */
+
         const subproc = ChildProcess.spawn(npmCmd, ['init'], { cwd });
 
         subproc.stdout.pipe(ctx.options.out, { end: false });

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "hpal": "./bin/hpal"
   },
   "scripts": {
-    "test": "lab -a @hapi/code -t 100 -L test/*.js",
-    "coveralls": "lab -r lcov test/*.js | coveralls"
+    "test": "lab -a @hapi/code -t 100 -L test/index.js",
+    "coveralls": "lab -r lcov test/index.js | coveralls"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "hpal": "./bin/hpal"
   },
   "scripts": {
-    "test": "lab -a @hapi/code -t 100 -L test/index.js",
-    "coveralls": "lab -r lcov test/index.js | coveralls"
+    "test": "lab -a @hapi/code -t 100 -L test/index.js test/print.js",
+    "coveralls": "lab -r lcov test/index.js test/print.js | coveralls"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,14 @@ const internals = {};
 
 describe('hpal', () => {
 
+    const normalize = (str) => {
+
+        // Naively normalizes string output for OS differences:
+        // backslashes to foreslashes (paths) and the OS end-of-line to \n.
+
+        return str && str.replace(/\\/g, '/').replace(RegExp(Os.EOL, 'g'), '\n');
+    };
+
     describe('CLI', () => {
 
         const rimraf = (file) => Util.promisify(Rimraf)(`${__dirname}/closet/${file}`, { disableGlob: true });
@@ -148,7 +156,7 @@ describe('hpal', () => {
 
                 expect(result.err).to.be.instanceof(DisplayError);
                 expect(result.output).to.equal('');
-                expect(result.errorOutput).to.contain('It\'s ambiguous which directory containing a .hc.js file to use: project-a/.hc.js, project-b/.hc.js');
+                expect(normalize(result.errorOutput)).to.contain('It\'s ambiguous which directory containing a .hc.js file to use: project-a/.hc.js, project-b/.hc.js');
                 expect(result.errorOutput.match(/,/g)).to.have.length(1);
             });
 
@@ -158,7 +166,7 @@ describe('hpal', () => {
 
                 expect(result1.err).to.be.instanceof(DisplayError);
                 expect(result1.output).to.equal('');
-                expect(result1.errorOutput).to.contain('It\'s ambiguous which directory containing a .hc.js file to use: ../project-a/.hc.js, ../project-b/.hc.js');
+                expect(normalize(result1.errorOutput)).to.contain('It\'s ambiguous which directory containing a .hc.js file to use: ../project-a/.hc.js, ../project-b/.hc.js');
                 expect(result1.errorOutput.match(/,/g)).to.have.length(1);
 
                 const OrigGlob = Glob.Glob;
@@ -184,7 +192,7 @@ describe('hpal', () => {
                 expect(Glob.Glob.notOriginal).to.not.exist();
                 expect(result2.err).to.be.instanceof(DisplayError);
                 expect(result2.output).to.equal('');
-                expect(result2.errorOutput).to.contain('It\'s ambiguous which directory containing a .hc.js file to use: ../project-b/.hc.js, ../project-a/.hc.js');
+                expect(normalize(result2.errorOutput)).to.contain('It\'s ambiguous which directory containing a .hc.js file to use: ../project-b/.hc.js, ../project-a/.hc.js');
                 expect(result2.errorOutput.match(/,/g)).to.have.length(1);
             });
 
@@ -197,7 +205,7 @@ describe('hpal', () => {
                 const result = await RunUtil.cli(['make', 'route'], 'ambiguous-hc-file/project-a');
 
                 expect(result.err).to.not.exist();
-                expect(result.output).to.contain('Wrote routes/index.js');
+                expect(normalize(result.output)).to.contain('Wrote routes/index.js');
                 expect(result.errorOutput).to.equal('');
 
                 const contents = await read('ambiguous-hc-file/project-a/routes/index.js');
@@ -214,7 +222,7 @@ describe('hpal', () => {
                 const result = await RunUtil.cli(['make', 'route'], 'non-ambiguous-hc-file-cwd/project-a');
 
                 expect(result.err).to.not.exist();
-                expect(result.output).to.contain('Wrote ../project-b/routes/index.js');
+                expect(normalize(result.output)).to.contain('Wrote ../project-b/routes/index.js');
                 expect(result.errorOutput).to.equal('');
 
                 const contents = await read('non-ambiguous-hc-file-cwd/project-b/routes/index.js');
@@ -238,7 +246,7 @@ describe('hpal', () => {
                 expect(result.err).to.be.instanceof(DisplayError);
                 expect(result.output).to.equal('');
                 expect(result.errorOutput).to.contain('The file');
-                expect(result.errorOutput).to.contain('file-already-exists/routes/some-route.js');
+                expect(normalize(result.errorOutput)).to.contain('file-already-exists/routes/some-route.js');
                 expect(result.errorOutput).to.contain('already exists.');
             });
 
@@ -318,7 +326,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/routes/index.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/routes/index.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('list-as-dir/lib/routes/index.js');
@@ -342,7 +350,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/routes.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/routes.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('list-as-file/lib/routes.js');
@@ -365,7 +373,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/bind/index.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/bind/index.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('single-as-dir/lib/bind/index.js');
@@ -388,7 +396,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/bind.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/bind.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('single-as-file/lib/bind.js');
@@ -431,7 +439,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/bind.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/bind.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('single-as-file/lib/bind.js');
@@ -451,7 +459,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/x.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/x.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('no-example-or-signature/lib/x.js');
@@ -478,7 +486,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/x.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/x.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('no-example-with-signature/lib/x.js');
@@ -509,7 +517,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/x.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/x.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('with-example-and-signature/lib/x.js');
@@ -540,7 +548,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/x.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/x.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('with-example-and-requires/lib/x.js');
@@ -571,7 +579,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/x/index.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/x/index.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('listed-example/lib/x/index.js');
@@ -591,7 +599,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/x/y.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/x/y.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('listed-example/lib/x/y.js');
@@ -619,7 +627,7 @@ describe('hpal', () => {
 
                     const result = await promise;
                     expect(result.err).to.not.exist();
-                    expect(result.output).to.contain('Wrote lib/x.js');
+                    expect(normalize(result.output)).to.contain('Wrote lib/x.js');
                     expect(result.errorOutput).to.equal('');
 
                     const contents = await read('skip-use-strict-header/lib/x.js');
@@ -1392,7 +1400,7 @@ describe('hpal', () => {
 
                 expect(result.err).to.be.instanceof(DisplayError);
                 expect(result.output).to.equal('');
-                expect(result.errorOutput).to.contain(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server.`);
+                expect(normalize(result.errorOutput)).to.contain(`No server found! To run commands the current project must export { deployment: async () => server } from ${normalize(root)}/server.`);
             });
 
             it('errors hard when a bad require happens in the server.', async () => {
@@ -1408,7 +1416,7 @@ describe('hpal', () => {
 
                 expect(result.err).to.be.instanceof(DisplayError);
                 expect(result.output).to.equal('');
-                expect(result.errorOutput).to.contain(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server.`);
+                expect(normalize(result.errorOutput)).to.contain(`No server found! To run commands the current project must export { deployment: async () => server } from ${normalize(root)}/server.`);
             });
 
             it('errors when calling a vanilla or default command that does not exist.', async () => {

--- a/test/print.js
+++ b/test/print.js
@@ -7,12 +7,13 @@
 const Os = require('os');
 const Lab = require('@hapi/lab');
 const Code = require('@hapi/code');
+const Chalk = require('chalk'); // Implicitly from marked-terminal
 const StripAnsi = require('strip-ansi');
 const Print = require('../lib/print');
 
 // Test shortcuts
 
-const { describe, it } = exports.lab = Lab.script();
+const { describe, it, before, after } = exports.lab = Lab.script();
 const { expect } = Code;
 
 const internals = {};
@@ -427,6 +428,25 @@ describe('Print.requires()', () => {
 
 describe('Print.markdownSection()', () => {
 
+    // We force colors on these tests since they affect the output
+    // and Windows CI has colors disabled implicitly via chalk.
+    // In theory it should not affect output since we normalize for
+    // ansi colors here, but it does due to limitations of marked-terminal.
+
+    const { enabled: origEnabled, level: origLevel } = Chalk;
+
+    before(() => {
+
+        Chalk.enabled = true;
+        Chalk.level = 1;
+    });
+
+    after(() => {
+
+        Chalk.enabled = origEnabled;
+        Chalk.level = origLevel;
+    });
+
     const p = Print.markdownSection;
 
     it('prints section in middle of markdown file.', () => {
@@ -525,6 +545,25 @@ describe('Print.markdownSection()', () => {
 });
 
 describe('Print.markdownListItem()', () => {
+
+    // We force colors on these tests since they affect the output
+    // and Windows CI has colors disabled implicitly via chalk.
+    // In theory it should not affect output since we normalize for
+    // ansi colors here, but it does due to limitations of marked-terminal.
+
+    const { enabled: origEnabled, level: origLevel } = Chalk;
+
+    before(() => {
+
+        Chalk.enabled = true;
+        Chalk.level = 1;
+    });
+
+    after(() => {
+
+        Chalk.enabled = origEnabled;
+        Chalk.level = origLevel;
+    });
 
     const p = Print.markdownListItem;
 


### PR DESCRIPTION
Building directly on top of #30 #35 to resolve #16.  Had a good long fight with windows CI, but I think we're there, if not for some hard-to-resolve flakiness in the windows tests such as intermittent EBUSY on files during cleanup.  One of the biggest surprises is that terminal color support affects the output of marked-terminal (e.g. how many newlines appear in output).  There's probably a bug report to file over there some point in the near future.