### PR TITLE
Ensure hpal new maintains alphabetical order of deps lists

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -3,7 +3,6 @@
 const Os = require('os');
 const Path = require('path');
 const ChildProcess = require('child_process');
-const StableStringify = require('json-stable-stringify');
 const Helpers = require('../helpers');
 const DisplayError = require('../display-error');
 
@@ -85,45 +84,37 @@ module.exports = async (cwd, dir, ctx) => {
         'directories'
     ];
 
-    const isDep = (name) => finalPkg.dependencies.hasOwnProperty(name);
-    const isDevDep = (name) => finalPkg.devDependencies.hasOwnProperty(name);
     const cmp = (x, y) => {
 
-        // Full-coverage here depends on input package file having keys to trigger
-        // all possible paths. The boilerplate's doesn't
-        // Only cases tested by package.json's entire set of keys is all false
-        // and half-true both ways (both deps or both dev deps).
-        /* $lab:coverage:off$ */
-        if (
-            (isDep(x.key) && isDep(y.key)) ||
-            (isDevDep(x.key) && isDevDep(y.key))
-        ) {
-            // boilerplate package.json deps are already alphabetical,
-            // so, the if clause is always true, meaning its only half-covered b/c false branch not tripped
-            // (this registers as missing coverage in node 12, but not 10)
-            // and the else branch is uncovered (never reached)
-            if (x.key > y.key) {
-                return 1;
-            }
-            else if (x.key < y.key) {
-                return -1;
-            }
-        }
-        /* $lab:coverage:on$ */
-
-        const xScore = order.indexOf(x.key) === -1 ? order.length : order.indexOf(x.key);
-        const yScore = order.indexOf(y.key) === -1 ? order.length : order.indexOf(y.key);
-
+        const xScore = order.indexOf(x) === -1 ? order.length : order.indexOf(x);
+        const yScore = order.indexOf(y) === -1 ? order.length : order.indexOf(y);
         return xScore - yScore;
     };
 
-    const finalPkgStringified = StableStringify(finalPkg, { cmp, space: 2 });
+    finalPkg = internals.sortObject(finalPkg, cmp);
+    finalPkg.dependencies = internals.sortObject(finalPkg.dependencies);
+    finalPkg.devDependencies = internals.sortObject(finalPkg.devDependencies);
+    const finalPkgStringified = JSON.stringify(finalPkg, null, 2);
+
     await Promise.all([
         Helpers.writeFile(Path.join(dir, 'package.json'), `${finalPkgStringified}${Os.EOL}`),
         Helpers.writeFile(Path.join(dir, 'README.md'), `# ${pkg.name}${Os.EOL}`)
     ]);
 
     await Helpers.exec('git add package.json README.md', { cwd: dir });
+};
+
+// TODO Give credit
+// bic'd from here: https://github.com/domenic/sorted-object/blob/master/lib/sorted-object.js
+// slightly tweaked and stylized per hapi linting, changed to accept a custom sorting function
+internals.sortObject = (input, fn) => {
+
+    return Object.keys(input).sort(fn)
+        .reduce((output, key) => {
+
+            output[key] = input[key];
+            return output;
+        }, {});
 };
 
 internals.ensureGitAndNpm = async ({ colors }) => {

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -85,7 +85,31 @@ module.exports = async (cwd, dir, ctx) => {
         'directories'
     ];
 
+    const isDep = (name) => finalPkg.dependencies.hasOwnProperty(name);
+    const isDevDep = (name) => finalPkg.devDependencies.hasOwnProperty(name);
     const cmp = (x, y) => {
+
+        // Full-coverage here depends on input package file having keys to trigger
+        // all possible paths. The boilerplate's doesn't
+        // Only cases tested by package.json's entire set of keys is all false
+        // and half-true both ways (both deps or both dev deps).
+        /* $lab:coverage:off$ */
+        if (
+            (isDep(x.key) && isDep(y.key)) ||
+            (isDevDep(x.key) && isDevDep(y.key))
+        ) {
+            // boilerplate package.json deps are already alphabetical,
+            // so, the if clause is always true, meaning its only half-covered b/c false branch not tripped
+            // (this registers as missing coverage in node 12, but not 10)
+            // and the else branch is uncovered (never reached)
+            if (x.key > y.key) {
+                return 1;
+            }
+            else if (x.key < y.key) {
+                return -1;
+            }
+        }
+        /* $lab:coverage:on$ */
 
         const xScore = order.indexOf(x.key) === -1 ? order.length : order.indexOf(x.key);
         const yScore = order.indexOf(y.key) === -1 ? order.length : order.indexOf(y.key);

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -106,9 +106,7 @@ module.exports = async (cwd, dir, ctx) => {
     await Helpers.exec('git add package.json README.md', { cwd: dir });
 };
 
-// TODO Give credit
-// bic'd from here: https://github.com/domenic/sorted-object/blob/master/lib/sorted-object.js
-// slightly tweaked and stylized per hapi linting, changed to accept a custom sorting function
+// Bic'd and adapted from domenic/sorted-object (WTFPL)
 internals.sortObject = (input, fn) => {
 
     return Object.keys(input).sort(fn)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@hapi/wreck": "15.x.x",
     "bin-v8-flags-filter": ">=1.2.0 <2",
     "glob": "7.x.x",
-    "json-stable-stringify": "1.x.x",
     "marked": "0.7.x",
     "marked-terminal": "3.x.x",
     "mkdirp": "0.5.x",

--- a/test/index.js
+++ b/test/index.js
@@ -678,6 +678,26 @@ describe('hpal', () => {
                 }
             };
 
+            const completePkgKeysOrder = [
+                'name',
+                'version',
+                'description',
+                'author',
+                'license',
+                'main',
+                'directories',
+                'scripts',
+                'dependencies',
+                'devDependencies'
+            ];
+
+            const bailedPkgKeysOrder = [
+                'main',
+                'scripts',
+                'dependencies',
+                'devDependencies'
+            ];
+
             it('creates a new pal project.', { timeout: 5000 }, async (flags) => {
 
                 flags.onCleanup = async () => await rimraf('new/my-project');
@@ -715,6 +735,7 @@ describe('hpal', () => {
                 expect(pkg.version).to.equal('1.0.0');
                 expect(pkg.dependencies).to.exist();
                 expect(pkg.devDependencies).to.exist();
+                expect(Object.keys(pkg)).to.equal(completePkgKeysOrder);
                 expect(Object.keys(pkg.dependencies)).to.equal(Object.keys(pkg.dependencies).sort());
                 expect(Object.keys(pkg.devDependencies)).to.equal(Object.keys(pkg.devDependencies).sort());
                 expect(pkgAsString.endsWith('\n')).to.equal(true);
@@ -768,6 +789,7 @@ describe('hpal', () => {
                 expect(pkg.version).to.not.exist();
                 expect(pkg.dependencies).to.exist();
                 expect(pkg.devDependencies).to.exist();
+                expect(Object.keys(pkg)).to.equal(bailedPkgKeysOrder);
                 expect(Object.keys(pkg.dependencies)).to.equal(Object.keys(pkg.dependencies).sort());
                 expect(Object.keys(pkg.devDependencies)).to.equal(Object.keys(pkg.devDependencies).sort());
                 expect(pkgAsString.endsWith('\n')).to.equal(true);

--- a/test/index.js
+++ b/test/index.js
@@ -715,6 +715,8 @@ describe('hpal', () => {
                 expect(pkg.version).to.equal('1.0.0');
                 expect(pkg.dependencies).to.exist();
                 expect(pkg.devDependencies).to.exist();
+                expect(Object.keys(pkg.dependencies)).to.equal(Object.keys(pkg.dependencies).sort());
+                expect(Object.keys(pkg.devDependencies)).to.equal(Object.keys(pkg.devDependencies).sort());
                 expect(pkgAsString.endsWith('\n')).to.equal(true);
                 expect(lib).to.exist();
                 expect(test).to.exist();
@@ -766,6 +768,8 @@ describe('hpal', () => {
                 expect(pkg.version).to.not.exist();
                 expect(pkg.dependencies).to.exist();
                 expect(pkg.devDependencies).to.exist();
+                expect(Object.keys(pkg.dependencies)).to.equal(Object.keys(pkg.dependencies).sort());
+                expect(Object.keys(pkg.devDependencies)).to.equal(Object.keys(pkg.devDependencies).sort());
                 expect(pkgAsString.endsWith('\n')).to.equal(true);
                 expect(lib).to.exist();
                 expect(test).to.exist();


### PR DESCRIPTION
This work addresses #38 

Alphabetically sort keys that we can reasonably guess are dependencies or devDependencies (I say guess b/c it's possible to trick those guesses if keys in other nodes of package.json match those in dependencies or devDependencies e.g. if there were scripts named `confidence` and `eslint`, for example). This is imprecise, but I went this way to try to avoid alphabetizing the non-dependency list "2nd-level" keys e.g. scripts (I tried a regex replace and reparse approach on just our dependencies, which felt a little more precise, but this fell down b/c i found it impossible to get the indentation of the replaced text right. This killed me inside a bit 🤡 )

Clearly, I bailed on testing thoroughly :) I noted in comments why I turned coverage off in the changes to the stable-stringify comparison function. I think the main issue with testing those cases is I couldn't figure out how to replace the `boilerplate`'s package.json with an arbitrary file, one I could build to trigger the cases uncovered by the original package.json. I bailed on this for now since it seemed tricky enough that it could be a time sink and I'd rather first confirm with you this solution seems sane enough before proceeding with any testing deepdive.


#### Background, if helpful

I don't entirely know why this issue was happening, but, as @devinivy noted [here](https://github.com/hapipal/hpal/issues/38#issuecomment-610961542), this appears to be due to reliance on something in v8's internals. Specifically, it looks like node 12 and 10 differ in how they preprocess an input array for sort e.g. for the boilerplate's list of `devDependencies`, running `devDepsNames.sort(() => 0)` (i.e. do not change list order) on both versions yields alphabetical results in node 12 and the non-alphabetized list seen on the linked issue. As for WHY node 10 does this, I haven't the slightest :) 

Further reading if it helps. I don't understand these resources much at all, just enough to takeaway that sorting in node 12 is expectedly different from 10 🎺 :
- https://github.com/nodejs/node/issues/24294
- https://v8.dev/blog/array-sort