### PR TITLE
Support command descriptions specified as a function, publicize ctx.colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,10 @@ Any hapi plugin can create commands that are runnable with `hpal run`!  Commands
      - `server` - the initialized hapi server.
      - `args` - an array of all the command's CLI arguments.  For example, running `hpal run my-plugin --custom-flag value` will result in `args` being `['--custom-flag', 'value']`.
      - `root` - an absolute path to the project's root directory.
-     - `ctx` - a context object containing some hpal internals that may be useful during testing.  Also contains an error class `DisplayError` than can be used to indicate a "safe" failure to hpal.  Throwing a `DisplayError` will output the error's `message` and exit the process with code `1`, but not display a stack trace as would happen with an unexpected error.
-   - `description` - a string description of the command displayed by `hpal run --list`.
+     - `ctx` - a context object containing some hpal internals that may be useful during testing, plus some public helpers.  The following are public:
+       - `colors` - an object with functions for basic formatting of CLI output with colors and styles: `colors.green(str)`, `colors.yellow(str)`, `colors.red(str)`, `colors.grey(str)`, and `colors.bold(str)`.  When the CLI does not support color, these functions take no effect.
+       - `DisplayError` - a class that can be used to indicate a "safe" failure to hpal.  Throwing a `DisplayError` will output the error's `message` and exit the process with code `1`, but not display a stack trace as would happen with an unexpected error.
+   - `description` - a string description of the command displayed by `hpal run --list`.  May alternatively be a function with signature `function (ctx)` that receives `ctx` as described above and returns a string description.
 
 For example, here is a plugin that creates a command to display the server's route table,
 ```js

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -29,7 +29,8 @@ module.exports = async (cwd, list, cmd, args, ctx) => {
                 const commands = Object.keys(plugin.commands || {}).map((cmdName) => {
 
                     const name = pluginName.replace(/^hpal-/, '') + ((cmdName === 'default') ? '' : internals.kebabize(`:${cmdName}`));
-                    const description = internals.normalizeCommand(plugin.commands[cmdName]).description;
+                    const command = internals.normalizeCommand(plugin.commands[cmdName]);
+                    const description = typeof command.description === 'function' ? command.description(ctx) : command.description;
 
                     return { name, description };
                 });

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "hpal": "./bin/hpal"
   },
   "scripts": {
-    "test": "lab -a @hapi/code -t 100 -L -I 'FinalizationRegistry,WeakRef' test/index.js test/print.js",
-    "coveralls": "lab -r lcov -I 'FinalizationRegistry,WeakRef' test/index.js test/print.js | coveralls"
+    "test": "lab -a @hapi/code -t 100 -L -I \"FinalizationRegistry,WeakRef\" test/index.js test/print.js",
+    "coveralls": "lab -r lcov -I \"FinalizationRegistry,WeakRef\" test/index.js test/print.js | coveralls"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "hpal": "./bin/hpal"
   },
   "scripts": {
-    "test": "lab -a @hapi/code -t 100 -L test/index.js test/print.js",
-    "coveralls": "lab -r lcov test/index.js test/print.js | coveralls"
+    "test": "lab -a @hapi/code -t 100 -L -I 'FinalizationRegistry,WeakRef' test/index.js test/print.js",
+    "coveralls": "lab -r lcov -I 'FinalizationRegistry,WeakRef' test/index.js test/print.js | coveralls"
   },
   "repository": {
     "type": "git",

--- a/test/closet/run-list-commands/server.js
+++ b/test/closet/run-list-commands/server.js
@@ -14,6 +14,10 @@ exports.deployment = async () => {
             described: {
                 description: 'This is what I do',
                 command: () => null
+            },
+            describedFn: {
+                description: (ctx) => JSON.stringify({ ctx: Object.keys(ctx).sort() }),
+                command: () => null
             }
         });
     };
@@ -32,6 +36,10 @@ exports.deployment = async () => {
             camelCased: () => null,
             described: {
                 description: 'This is what I do',
+                command: () => null
+            },
+            describedFn: {
+                description: (ctx) => JSON.stringify({ ctx: Object.keys(ctx).sort() }),
                 command: () => null
             }
         });

--- a/test/index.js
+++ b/test/index.js
@@ -1500,10 +1500,14 @@ describe('hpal', () => {
                     '  hpal run x:camel-cased',
                     '  hpal run x:described',
                     '    • This is what I do',
+                    '  hpal run x:described-fn',
+                    '    • {"ctx":["DisplayError","colors","options","output"]}',
                     '  hpal run y',
                     '  hpal run y:camel-cased',
                     '  hpal run y:described',
-                    '    • This is what I do'
+                    '    • This is what I do',
+                    '  hpal run y:described-fn',
+                    '    • {"ctx":["DisplayError","colors","options","output"]}'
                 ].join('\n'));
             });
 


### PR DESCRIPTION
This PR consists of two small enhancements that work together, as recommended by @damusix in #47:
 - Make the `ctx.colors` CLI formatting utilities officially part of the public API.
 - Allow command descriptions to be specified as a function `(ctx) => description` (with access to those formatting utilities).