### PR TITLE
Prevent bin process from crashing on sigint when sent during npm init dialog

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -59,7 +59,16 @@ module.exports = async ({ cwd, dir, ctx }) => {
         Helpers.writeFile(Path.join(dir, 'README.md'), '')
     ]);
 
+
+    const ignore = () => {
+
+        /* $lab:coverage:off$ */
+        ctx.options.out.write('\n');
+        /* $lab:coverage:on$ */
+    };
+
     try {
+        process.on('SIGINT', ignore);
         await internals.npmInit(dir, ctx);
     }
     catch (ignoreErr) {
@@ -68,6 +77,9 @@ module.exports = async ({ cwd, dir, ctx }) => {
                 'Bailed on `npm init`, but continuing to setup your project with an incomplete package.json file.'
             ) + '\n'
         );
+    }
+    finally {
+        process.removeListener('SIGINT', ignore);
     }
 
     let finalPkg = await Helpers.readFile(Path.join(dir, 'package.json'));
@@ -156,6 +168,7 @@ internals.npmInit = (cwd, ctx) => {
 
         subproc.once('close', (code) => {
 
+            // code is null on Ctrl-C (SIGINT)
             if (code !== 0) {
                 return reject(new Error(`Failed with code: ${code}`));
             }

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -59,12 +59,16 @@ module.exports = async ({ cwd, dir, ctx }) => {
         Helpers.writeFile(Path.join(dir, 'README.md'), '')
     ]);
 
-    let reject;
+    const ignore = () => {
+
+        /* $lab:coverage:off$ */
+        ctx.options.out.write('\n');
+        /* $lab:coverage:on$ */
+    };
+
     try {
-        const dialog = internals.npmInit(dir, ctx);
-        reject = dialog.reject;
-        process.on('SIGINT', reject);
-        await dialog.promise;
+        process.on('SIGINT', ignore);
+        await internals.npmInit(dir, ctx);
     }
     catch (ignoreErr) {
         ctx.options.err.write(
@@ -74,7 +78,7 @@ module.exports = async ({ cwd, dir, ctx }) => {
         );
     }
     finally {
-        process.removeListener('SIGINT', reject);
+        process.removeListener('SIGINT', ignore);
     }
 
     let finalPkg = await Helpers.readFile(Path.join(dir, 'package.json'));
@@ -139,8 +143,7 @@ internals.ensureGitAndNpm = async ({ colors }) => {
 
 internals.npmInit = (cwd, ctx) => {
 
-    const npmInitDialog = {};
-    npmInitDialog.promise = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
 
         // There is no way to cover this on a single platform
         /* $lab:coverage:off$ */
@@ -148,14 +151,6 @@ internals.npmInit = (cwd, ctx) => {
         /* $lab:coverage:on$ */
 
         const subproc = ChildProcess.spawn(npmCmd, ['init'], { cwd });
-
-        /* $lab:coverage:off$ */
-        npmInitDialog.reject = () => {
-
-            subproc.kill('SIGINT');
-            ctx.options.out.write('\n');
-        };
-        /* $lab:coverage:on$ */
 
         subproc.stdout.pipe(ctx.options.out, { end: false });
         ctx.options.in.pipe(subproc.stdin);
@@ -180,6 +175,4 @@ internals.npmInit = (cwd, ctx) => {
             return resolve();
         });
     });
-
-    return npmInitDialog;
 };

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -59,17 +59,12 @@ module.exports = async ({ cwd, dir, ctx }) => {
         Helpers.writeFile(Path.join(dir, 'README.md'), '')
     ]);
 
-
-    const ignore = () => {
-
-        /* $lab:coverage:off$ */
-        ctx.options.out.write('\n');
-        /* $lab:coverage:on$ */
-    };
-
+    let reject;
     try {
-        process.on('SIGINT', ignore);
-        await internals.npmInit(dir, ctx);
+        const dialog = internals.npmInit(dir, ctx);
+        reject = dialog.reject;
+        process.on('SIGINT', reject);
+        await dialog.promise;
     }
     catch (ignoreErr) {
         ctx.options.err.write(
@@ -79,7 +74,7 @@ module.exports = async ({ cwd, dir, ctx }) => {
         );
     }
     finally {
-        process.removeListener('SIGINT', ignore);
+        process.removeListener('SIGINT', reject);
     }
 
     let finalPkg = await Helpers.readFile(Path.join(dir, 'package.json'));
@@ -144,7 +139,8 @@ internals.ensureGitAndNpm = async ({ colors }) => {
 
 internals.npmInit = (cwd, ctx) => {
 
-    return new Promise((resolve, reject) => {
+    const npmInitDialog = {};
+    npmInitDialog.promise = new Promise((resolve, reject) => {
 
         // There is no way to cover this on a single platform
         /* $lab:coverage:off$ */
@@ -152,6 +148,14 @@ internals.npmInit = (cwd, ctx) => {
         /* $lab:coverage:on$ */
 
         const subproc = ChildProcess.spawn(npmCmd, ['init'], { cwd });
+
+        /* $lab:coverage:off$ */
+        npmInitDialog.reject = () => {
+
+            subproc.kill('SIGINT');
+            ctx.options.out.write('\n');
+        };
+        /* $lab:coverage:on$ */
 
         subproc.stdout.pipe(ctx.options.out, { end: false });
         ctx.options.in.pipe(subproc.stdin);
@@ -176,4 +180,6 @@ internals.npmInit = (cwd, ctx) => {
             return resolve();
         });
     });
+
+    return npmInitDialog;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -825,7 +825,7 @@ describe('hpal', () => {
                 expect(`${logError}`).to.contain('your current branch \'master\' does not have any commits');
             });
 
-            it('creates a new pal project when bailing on `npm init` by ^C press (SIGINT).', { timeout: 5000 }, async (flags) => {
+            it('creates a new pal project when bailing on `npm init` by ^C press (SIGINT).', { timeout: 5000, skip: process.platform === 'win32' }, async (flags) => {
 
                 flags.onCleanup = async () => await rimraf('new/sigint-on-npm-init');
 

--- a/test/run-util.js
+++ b/test/run-util.js
@@ -6,12 +6,12 @@ const Stream = require('stream');
 const DisplayError = require('../lib/display-error');
 const Hpal = require('..');
 
-exports.bin = (argv, cwd) => {
+exports.bin = (argv, cwd, bailOnNpmInit) => {
 
     return new Promise((resolve, reject) => {
 
         const path = Path.join(__dirname, '..', 'bin', 'hpal');
-        const cli = ChildProcess.spawn('node', [].concat(path, argv), { cwd: cwd || __dirname });
+        const cli = ChildProcess.spawn('node', [].concat(path, argv), { cwd: cwd || __dirname, ...(bailOnNpmInit && { detached: true }) });
 
         let output = '';
         let errorOutput = '';
@@ -21,6 +21,12 @@ exports.bin = (argv, cwd) => {
 
             output += data;
             combinedOutput += data;
+
+            if (bailOnNpmInit && ~data.toString().indexOf('Press ^C at any time to quit.')) {
+                // negative process id kills all processes led by the CLI process (process group id = cli.pid)
+                // this group includes the npm init child process spawned by the new command
+                process.kill(-cli.pid, 'SIGINT');
+            }
         });
 
         cli.stderr.on('data', (data) => {

--- a/test/run-util.js
+++ b/test/run-util.js
@@ -23,7 +23,7 @@ exports.bin = (argv, cwd, bailOnNpmInit) => {
             combinedOutput += data;
 
             if (bailOnNpmInit && ~data.toString().indexOf('Press ^C at any time to quit.')) {
-                cli.kill('SIGINT');
+                cli.kill(process.platform === 'win32' ? undefined : 'SIGINT');
             }
         });
 

--- a/test/run-util.js
+++ b/test/run-util.js
@@ -11,7 +11,7 @@ exports.bin = (argv, cwd, bailOnNpmInit) => {
     return new Promise((resolve, reject) => {
 
         const path = Path.join(__dirname, '..', 'bin', 'hpal');
-        const cli = ChildProcess.spawn('node', [].concat(path, argv), { cwd: cwd || __dirname, ...(bailOnNpmInit && { detached: true }) });
+        const cli = ChildProcess.spawn('node', [].concat(path, argv), { cwd: cwd || __dirname });
 
         let output = '';
         let errorOutput = '';
@@ -23,9 +23,7 @@ exports.bin = (argv, cwd, bailOnNpmInit) => {
             combinedOutput += data;
 
             if (bailOnNpmInit && ~data.toString().indexOf('Press ^C at any time to quit.')) {
-                // negative process id kills all processes led by the CLI process (process group id = cli.pid)
-                // this group includes the npm init child process spawned by the new command
-                process.kill(-cli.pid, 'SIGINT');
+                cli.kill('SIGINT');
             }
         });
 


### PR DESCRIPTION
Addresses #42 

Now, on starting the npm init dialog, we ignore `SIGINT` on our main process, so when you press ctrl + C (or however else you fire off a `SIGINT` signal), as that dialog prompts you to do to quit at anytime, instead of the main process exiting, the `SIGINT` reaches the npm init child process spawned by the new command, which then exits.