### PR TITLE
Support and test TypeScript and ESM

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 test/closet/haute-couture-broken/node_modules/haute-couture.js
 test/closet/new/**
+test/closet/run-command-ts/**

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2020, Devin Ivy and collaborators
+Copyright (c) 2017-2021, Devin Ivy and collaborators
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/bin/_hpal
+++ b/bin/_hpal
@@ -1,10 +1,18 @@
 #!/usr/bin/env node
 'use strict';
 
+const Bounce = require('@hapi/bounce');
 const Hpal = require('..');
 const DisplayError = require('../lib/display-error');
 
 (async () => {
+
+    try {
+        require('ts-node').register(); // Support .hc.ts files, etc.
+    }
+    catch (err) {
+        Bounce.ignore(err, { code: 'MODULE_NOT_FOUND' });
+    }
 
     try {
 

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Path = require('path');
+const Mo = require('mo-walk');
 const PkgDir = require('pkg-dir');
 const Helpers = require('../helpers');
 const DisplayError = require('../display-error');
@@ -92,28 +93,17 @@ internals.getServer = async (root, ctx) => {
 
     const path = Path.join(root, 'server');
 
-    try {
+    const [srv] = await Mo.tryToResolve(path) || [];
 
-        const srv = require(path);
-
-        if (typeof srv.deployment !== 'function') {
-            throw new DisplayError(ctx.colors.red(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server.`));
-        }
-
-        const server = await srv.deployment();
-
-        await server.initialize();
-
-        return server;
+    if (!srv || typeof srv.deployment !== 'function') {
+        throw new DisplayError(ctx.colors.red(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server.`));
     }
-    catch (err) {
 
-        if (err.code === 'MODULE_NOT_FOUND' && err.message.includes(`'${path}'`)) {
-            throw new DisplayError(ctx.colors.red(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server.`));
-        }
+    const server = await srv.deployment();
 
-        throw err;
-    }
+    await server.initialize();
+
+    return server;
 };
 
 internals.kebabize = (str) => str.replace(/[A-Z]/g, (m) => (`-${m}`).toLowerCase());

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,7 @@ const Util = require('util');
 const AsyncHooks = require('async_hooks');
 const ChildProcess = require('child_process');
 const Mkdirp = require('mkdirp');
+const Mo = require('mo-walk');
 const Toys = require('@hapipal/toys');
 const Bounce = require('@hapi/bounce');
 const Glob = require('glob');
@@ -27,29 +28,26 @@ exports.mkdirp = Mkdirp;
 
 exports.getAmendments = async (root, ctx, { amendmentsRequired = true } = {}) => {
 
-    // Fail early to avoid getAmendmentFile(), which can be expensive (globbing)
+    // Fail early to avoid getHcDirectory(), which can be expensive (globbing)
     const hc = internals.getHauteCouture(root, ctx);
 
-    let amendmentFile;
+    let hcDirectory;
 
     try {
-        amendmentFile = await internals.getAmendmentFile(root, ctx);
+        hcDirectory = await internals.getHcDirectory(root, ctx);
     }
     catch (err) {
-
         Bounce.ignore(err, DisplayError);
-
         if (amendmentsRequired) {
             throw err;
         }
-
-        amendmentFile = null;
     }
 
-    const overrides = (amendmentFile !== null) ? require(amendmentFile) : {};
+    const resolved = hcDirectory && await Mo.tryToResolve(Path.join(hcDirectory, '.hc'));
+    const overrides = resolved ? Mo.getDefaultExport(...resolved) : {};
     const amendments = hc.amendments(overrides);
 
-    return { amendments, file: amendmentFile };
+    return { amendments, file: resolved ? resolved[1] : null  };
 };
 
 exports.withAsyncStorage = (command, run) => {
@@ -91,7 +89,7 @@ internals.getHauteCouture = (root, { colors }) => {
 
 internals.glob = Util.promisify((pattern, opts, cb) => new Glob.Glob(pattern, opts, cb));
 
-internals.getAmendmentFile = async (root, ctx) => {
+internals.getHcDirectory = async (root, ctx) => {
 
     const { colors, options: { cwd } } = ctx;
 
@@ -113,8 +111,6 @@ internals.getAmendmentFile = async (root, ctx) => {
 
     const isAncestorPathOrNoRelation = (pathA, pathB) => isAncestorPath(pathA, pathB) || !isChildPath(pathA, pathB);
 
-    const makeFilename = (path) => Path.resolve(path, '.hc.js');
-
     const cull = (paths, predicate) => {
 
         let i = 0;
@@ -127,27 +123,29 @@ internals.getAmendmentFile = async (root, ctx) => {
 
         if (paths.length > 1) {
             const relativize = (path) => Path.relative(cwd, path);
-            const filenames = paths.map(makeFilename).map(relativize);
-            throw new DisplayError(colors.red(`It's ambiguous which directory containing a .hc.js file to use: ${filenames.join(', ')}`));
+            const pathnames = paths.map(relativize);
+            throw new DisplayError(colors.red(`It's ambiguous which directory containing a .hc.* file to use: ${pathnames.join(', ')}`));
         }
 
         return paths[0];
     };
 
-    const amendmentFiles = await internals.glob('**/.hc.js', {
+    const unique = (arr) => [...new Set(arr)];
+
+    const amendmentFiles = await internals.glob(`**/.hc.{${Mo.defaultExtensions.join(',')}}`, {
         cwd: root,
         absolute: true,
         ignore: 'node_modules/**'
     });
 
-    const amendmentPaths = amendmentFiles.map(Path.dirname);
+    const amendmentPaths = unique(amendmentFiles.map(Path.dirname));
 
     // Prefer nearest ancestor...
 
     const ancestorPaths = amendmentPaths.filter((path) => isAncestorPath(path, cwd));
 
     if (ancestorPaths.length) {
-        return makeFilename(cull(ancestorPaths, isChildPath));
+        return cull(ancestorPaths, isChildPath);
     }
 
     // ... then nearest (unambiguous) child...
@@ -155,14 +153,14 @@ internals.getAmendmentFile = async (root, ctx) => {
     const childPaths = amendmentPaths.filter((path) => isChildPath(path, cwd));
 
     if (childPaths.length) {
-        return makeFilename(cull(childPaths, isAncestorPathOrNoRelation));
+        return cull(childPaths, isAncestorPathOrNoRelation);
     }
 
     // ... then any (unambiguous) side-paths!
 
     if (amendmentPaths.length) {
-        return makeFilename(cull(amendmentPaths, isAncestorPathOrNoRelation));
+        return cull(amendmentPaths, isAncestorPathOrNoRelation);
     }
 
-    throw new DisplayError(colors.red('There\'s no directory in this project containing a .hc.js file.'));
+    throw new DisplayError(colors.red('There\'s no directory in this project containing a .hc.* file.'));
 };

--- a/package.json
+++ b/package.json
@@ -47,9 +47,18 @@
     "marked": "1.x.x",
     "marked-terminal": "4.x.x",
     "mkdirp": "1.x.x",
+    "mo-walk": ">=1.1.0 <2",
     "pkg-dir": "5.x.x",
     "pluralize": "8.x.x",
     "supports-color": "7.x.x"
+  },
+  "peerDependencies": {
+    "ts-node": "10.x.x"
+  },
+  "peerDependenciesMeta": {
+    "@hapi/nes": {
+      "ts-node": true
+    }
   },
   "devDependencies": {
     "@hapi/boom": "9.x.x",
@@ -57,8 +66,10 @@
     "@hapi/hapi": "20.x.x",
     "@hapi/lab": "24.x.x",
     "@hapipal/haute-couture": "4.x.x",
+    "@types/hapi__hapi": "20.x.x",
     "coveralls": "3.x.x",
     "rimraf": "3.x.x",
-    "strip-ansi": "6.x.x"
+    "strip-ansi": "6.x.x",
+    "ts-node": "10.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,11 +53,15 @@
     "supports-color": "7.x.x"
   },
   "peerDependencies": {
-    "ts-node": "10.x.x"
+    "ts-node": "10.x.x",
+    "typescript": "*"
   },
   "peerDependenciesMeta": {
-    "@hapi/nes": {
-      "ts-node": true
+    "ts-node": {
+      "optional": true
+    },
+    "typescript": {
+      "optional": true
     }
   },
   "devDependencies": {
@@ -70,6 +74,7 @@
     "coveralls": "3.x.x",
     "rimraf": "3.x.x",
     "strip-ansi": "6.x.x",
-    "ts-node": "10.x.x"
+    "ts-node": "10.x.x",
+    "typescript": "4.x.x"
   }
 }

--- a/test/closet/non-ambiguous-hc-file-cwd-esm/package.json
+++ b/test/closet/non-ambiguous-hc-file-cwd-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "non-ambiguous-hc-file-cwd-esm"
+}

--- a/test/closet/non-ambiguous-hc-file-cwd-esm/project-b/.hc.mjs
+++ b/test/closet/non-ambiguous-hc-file-cwd-esm/project-b/.hc.mjs
@@ -1,0 +1,5 @@
+import * as HauteCouture from '@hapipal/haute-couture';
+
+export default {
+    pluggums: HauteCouture.amendment('plugins')
+};

--- a/test/closet/run-command-esm/package.json
+++ b/test/closet/run-command-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-command-esm"
+}

--- a/test/closet/run-command-esm/server.mjs
+++ b/test/closet/run-command-esm/server.mjs
@@ -1,0 +1,35 @@
+import * as Hapi from '@hapi/hapi';
+
+export const deployment = async () => {
+
+    const server = Hapi.server();
+
+    const register = (srv) => {
+
+        srv.expose('commands', {
+            someCommand: (rootServer, args, root, ctx) => {
+
+                ctx.options.cmd = [rootServer, args, root, ctx];
+
+                const stop = rootServer.stop;
+                rootServer.stop = async () => {
+
+                    rootServer.stop = stop;
+
+                    await rootServer.stop();
+
+                    rootServer.stopped = true;
+                };
+            }
+        });
+    };
+
+    const plugin = {
+        name: 'x',
+        register
+    };
+
+    await server.register(plugin);
+
+    return server;
+};

--- a/test/closet/run-command-ts/package.json
+++ b/test/closet/run-command-ts/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-command-ts"
+}

--- a/test/closet/run-command-ts/server.ts
+++ b/test/closet/run-command-ts/server.ts
@@ -1,0 +1,25 @@
+import * as Hapi from '@hapi/hapi';
+
+export const deployment = async () => {
+
+    const server = Hapi.server();
+
+    const register = (srv: Hapi.Server) => {
+
+        srv.expose('commands', {
+            someCommand: () => {
+
+                console.log('some-command was run!');
+            }
+        });
+    };
+
+    const plugin = {
+        name: 'x',
+        register
+    };
+
+    await server.register(plugin);
+
+    return server;
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1763,13 +1763,13 @@ describe('hpal', () => {
             expect(result.errorOutput).to.equal('');
         });
 
-        it('support TypeScript files.', async () => {
+        it('supports TypeScript files.', async () => {
 
             const result = await RunUtil.bin(['run', 'x:some-command'], `${__dirname}/closet/run-command-ts`);
 
+            expect(result.errorOutput).to.equal('');
             expect(result.code).to.equal(0);
             expect(result.output).to.contain('some-command was run!');
-            expect(result.errorOutput).to.equal('');
         });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1763,7 +1763,7 @@ describe('hpal', () => {
             expect(result.errorOutput).to.equal('');
         });
 
-        it('supports TypeScript files.', async () => {
+        it('supports TypeScript files.', { timeout: 5000 }, async () => { // Slow likely due to TypeScript init
 
             const result = await RunUtil.bin(['run', 'x:some-command'], `${__dirname}/closet/run-command-ts`);
 


### PR DESCRIPTION
Supports amendments in `.hc.mjs` and `.hc.ts` files, for example, while using `hpal docs` and `hpal make`.  Also allows `server.mjs` and `server.ts` files, for example, while using `hpal run`.  If you want to use TypeScript, just ensure typescript and ts-node v10 is installed in your project 👍 

Pairs with https://github.com/hapipal/haute-couture/pull/84